### PR TITLE
Replaced random.cat with the TheCatAPI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     connection_pool (2.2.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    e2mmap (0.1.0)
     fast-stemmer (1.0.2)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -95,6 +96,8 @@ GEM
     rake (13.0.0)
     sqlite3 (1.4.1)
     thread_safe (0.3.6)
+    thwait (0.2.0)
+      e2mmap
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -113,6 +116,7 @@ DEPENDENCIES
   activerecord
   chatx!
   classifier-reborn (= 2.1.0)
+  e2mmap
   htmlentities
   httparty
   pry
@@ -121,6 +125,7 @@ DEPENDENCIES
   se-api!
   se-realtime!
   sqlite3
+  thwait
 
 BUNDLED WITH
    1.17.2

--- a/comment_scan/replier.rb
+++ b/comment_scan/replier.rb
@@ -336,7 +336,7 @@ class Replier
     def cat_mentions(msg_id, chat_user, room_id, message)
         return false unless contains_cat(message) && animals_on?(room_id)
 
-        cat_response = HTTParty.get("https://api.thecatapi.com/v1/images/search", :headers => { 'content-type': 'application/json', 'x-api-key': '7d3d11b1-fe0d-4303-9eba-3d1f8dce3cdf' }) #api-key is necessary to fetch image
+        cat_response = HTTParty.get("https://api.thecatapi.com/v1/images/search", :headers => { 'content-type': 'application/json', 'x-api-key': '' }) #api-key is necessary to fetch image
         #@chatter.say(cat_response.parsed_response[0]);
         if cat_response.length > 0
             @chatter.say(":#{msg_id} #{cat_response.parsed_response[0]["url"]}", room_id) # fetch ok

--- a/comment_scan/replier.rb
+++ b/comment_scan/replier.rb
@@ -336,14 +336,13 @@ class Replier
     def cat_mentions(msg_id, chat_user, room_id, message)
         return false unless contains_cat(message) && animals_on?(room_id)
 
-        cat_response = HTTParty.post("https://aws.random.cat/meow")
-        case cat_response.code
-            when 200 #All good!
-                @chatter.say(":#{msg_id} #{cat_response.parsed_response["file"]}", room_id)
-            when 404
-                @chatter.say("O noes! Cats not found!", room_id)
-            when 500...600
-                @chatter.say("ZOMG ERROR #{cat_response.code}...and no cats :(", room_id)
+        cat_response = HTTParty.get("https://api.thecatapi.com/v1/images/search", :headers => { 'content-type': 'application/json', 'x-api-key': '0605155b-c002-48bf-a3ab-45be10448c44' }) #api-key is necessary to fetch image
+        #@chatter.say(cat_response.parsed_response[0]);
+        if cat_response.length > 0
+            @chatter.say(":#{msg_id} #{cat_response.parsed_response[0]["url"]}", room_id) # fetch ok
+        else
+            @chatter.say("O noes! Cats not found! :(", room_id)
+
         end
         return true
     end

--- a/comment_scan/replier.rb
+++ b/comment_scan/replier.rb
@@ -336,7 +336,7 @@ class Replier
     def cat_mentions(msg_id, chat_user, room_id, message)
         return false unless contains_cat(message) && animals_on?(room_id)
 
-        cat_response = HTTParty.get("https://api.thecatapi.com/v1/images/search", :headers => { 'content-type': 'application/json', 'x-api-key': '0605155b-c002-48bf-a3ab-45be10448c44' }) #api-key is necessary to fetch image
+        cat_response = HTTParty.get("https://api.thecatapi.com/v1/images/search", :headers => { 'content-type': 'application/json', 'x-api-key': '' }) #api-key is necessary to fetch image
         #@chatter.say(cat_response.parsed_response[0]);
         if cat_response.length > 0
             @chatter.say(":#{msg_id} #{cat_response.parsed_response[0]["url"]}", room_id) # fetch ok

--- a/comment_scan/replier.rb
+++ b/comment_scan/replier.rb
@@ -336,7 +336,7 @@ class Replier
     def cat_mentions(msg_id, chat_user, room_id, message)
         return false unless contains_cat(message) && animals_on?(room_id)
 
-        cat_response = HTTParty.get("https://api.thecatapi.com/v1/images/search", :headers => { 'content-type': 'application/json', 'x-api-key': '' }) #api-key is necessary to fetch image
+        cat_response = HTTParty.get("https://api.thecatapi.com/v1/images/search", :headers => { 'content-type': 'application/json', 'x-api-key': '7d3d11b1-fe0d-4303-9eba-3d1f8dce3cdf' }) #api-key is necessary to fetch image
         #@chatter.say(cat_response.parsed_response[0]);
         if cat_response.length > 0
             @chatter.say(":#{msg_id} #{cat_response.parsed_response[0]["url"]}", room_id) # fetch ok


### PR DESCRIPTION
Since https://aws.random.cat/meow was taken down, I replaced the code using TheCatAPI.

I'm not too sure if I need any more error handling within the GET request or not since it only checks for `length`